### PR TITLE
Fix Docker deprecation warning

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,16 +1,10 @@
 FROM ruby:2.4.0-alpine
 
 RUN \
-  # update packages
   apk update && \
-
   apk add nodejs build-base libxml2-dev libxslt-dev && \
-
-  # gem 'mysql2'
   apk --no-cache add mysql-dev && \
-
-  # clear after installation
-rm -rf /var/cache/apk/*
+  rm -rf /var/cache/apk/*
 
 
 RUN mkdir /app


### PR DESCRIPTION
remove the comments inside the run command as this can cause error's in specific
environment's and are being remove soon.